### PR TITLE
Atualizada a configuração proposta, já que a mesma anteriormente esta…

### DIFF
--- a/app/controllers/admin/Error404Controller.php
+++ b/app/controllers/admin/Error404Controller.php
@@ -13,6 +13,7 @@ class Error404Controller extends \HXPHP\System\Controller
          * Isto ocorre porque os métodos de manipulação da view são apontados
          * para a raiz da pasta "app/views/".
          */
+		$this->view->setConfigs($this->configs, '', 'Error404Controller', 'index');
         $this->view->setHeader('header')
                 ->setPath('error404')
                 ->setFooter('footer')


### PR DESCRIPTION
...va lançando um erro fatal, acusando que a view não teria sido previamente criada, pois a antiga configuração redirecionava para "views\admin\error404\" e não para "views\error404\" como esperado.